### PR TITLE
fix: remove unnecessary onDeselect

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -219,11 +219,6 @@ export default class SuperSelect extends PureComponent {
     }
   }
 
-  onDeselect = value => {
-    const { onDeselect } = this.props
-    onDeselect && onDeselect(value)
-  }
-
   // 在搜索重新计算下拉滚动条高度
   onChange = (value, opt) => {
     // // 删除选中项时保持展开下拉列表状态
@@ -328,7 +323,6 @@ export default class SuperSelect extends PureComponent {
         optionLabelProp={optionLabelProp}
         dropdownStyle={dropdownStyle}
         onDropdownVisibleChange={this.setSuperDrowDownMenu}
-        onDeselect={this.onDeselect}
         ref={ele => (this.select = ele)}
         dropdownRender={menu => (
           <DropDownWrap


### PR DESCRIPTION
`onDeselect` 是有两个参数的，但是 `antd` 文档里面只写了一个，所以之前的代码会有问题，而且 `rc-select` 里面对 `onDeselect` 是否为空做了判断，这里就没必要再判断了，直接传下去就好了